### PR TITLE
Fix ID validation failure when browser is refreshed

### DIFF
--- a/io.asgardeo.tomcat.saml.agent/src/main/java/io/asgardeo/tomcat/saml/agent/SAML2SSOAgentFilter.java
+++ b/io.asgardeo.tomcat.saml.agent/src/main/java/io/asgardeo/tomcat/saml/agent/SAML2SSOAgentFilter.java
@@ -101,7 +101,7 @@ public class SAML2SSOAgentFilter implements Filter {
                 try {
                     samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
                     samlSSOManager.processResponse(request, response);
-                    if (!"true".equals(request.getAttribute(SSOAgentConstants.SHOULD_GO_TO_WELCOME_PAGE))) {
+                    if (!SSOAgentFilterUtils.shouldGoToWelcomePage(request)) {
                         response.sendRedirect(ssoAgentConfig.getSAML2().getACSURL());
                     }
                 } catch (SSOAgentException e) {
@@ -129,7 +129,6 @@ public class SAML2SSOAgentFilter implements Filter {
                 try {
                     samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
                     if (resolver.isHttpPostBinding()) {
-
                         boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
                         ssoAgentConfig.getSAML2().setPassiveAuthn(false);
                         String htmlPayload = samlSSOManager.buildPostRequest(request, response, true);
@@ -137,7 +136,7 @@ public class SAML2SSOAgentFilter implements Filter {
                         SSOAgentUtils.sendPostResponse(request, response, htmlPayload);
 
                     } else {
-                        //if "SSOAgentConstants.HTTP_BINDING_PARAM" is not defined, default to redirect
+                        // If "SSOAgentConstants.HTTP_BINDING_PARAM" is not defined, default to redirect.
                         boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
                         ssoAgentConfig.getSAML2().setPassiveAuthn(false);
                         String redirectUrl = samlSSOManager.buildRedirectRequest(request, true);
@@ -215,7 +214,7 @@ public class SAML2SSOAgentFilter implements Filter {
                 response.sendRedirect(indexPage);
                 return;
             }
-            // pass the request along the filter chain
+            // Pass the request along the filter chain.
             chain.doFilter(request, response);
 
         } catch (InvalidSessionException e) {

--- a/io.asgardeo.tomcat.saml.agent/src/main/java/io/asgardeo/tomcat/saml/agent/SAML2SSOAgentFilter.java
+++ b/io.asgardeo.tomcat.saml.agent/src/main/java/io/asgardeo/tomcat/saml/agent/SAML2SSOAgentFilter.java
@@ -86,25 +86,39 @@ public class SAML2SSOAgentFilter implements Filter {
 
             if (resolver.isSLORequest()) {
 
-                samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
-                LogoutResponse logoutResponse = samlSSOManager.doSLO(request);
-                String encodedRequestMessage = samlSSOManager.buildPostResponse(logoutResponse);
-                SSOAgentUtils.sendPostResponse(request, response, encodedRequestMessage);
+                try {
+                    samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
+                    LogoutResponse logoutResponse = samlSSOManager.doSLO(request);
+                    String encodedRequestMessage = samlSSOManager.buildPostResponse(logoutResponse);
+                    SSOAgentUtils.sendPostResponse(request, response, encodedRequestMessage);
+                } catch (SSOAgentException e) {
+                    handleException(request, response, ssoAgentConfig, e);
+                    return;
+                }
                 return;
             } else if (resolver.isSAML2SSOResponse()) {
 
-                samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
                 try {
+                    samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
                     samlSSOManager.processResponse(request, response);
+                    if (!"true".equals(request.getAttribute(SSOAgentConstants.SHOULD_GO_TO_WELCOME_PAGE))) {
+                        response.sendRedirect(ssoAgentConfig.getSAML2().getACSURL());
+                    }
                 } catch (SSOAgentException e) {
+                    if (e instanceof InvalidSessionException) {
+                        // Redirect to the index page when session is expired or user already logged out.
+                        LOGGER.log(Level.FINE, "Invalid Session!", e);
+                        response.sendRedirect(filterConfig.getServletContext().getContextPath());
+                        return;
+                    }
                     handleException(request, response, ssoAgentConfig, e);
                     return;
                 }
 
             } else if (resolver.isSAML2ArtifactResponse()) {
 
-                samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
                 try {
+                    samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
                     samlSSOManager.processArtifactResponse(request);
                 } catch (SSOAgentException e) {
                     handleException(request, response, ssoAgentConfig, e);
@@ -112,50 +126,82 @@ public class SAML2SSOAgentFilter implements Filter {
                 }
             } else if (resolver.isSLOURL()) {
 
-                samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
-                if (resolver.isHttpPostBinding()) {
+                try {
+                    samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
+                    if (resolver.isHttpPostBinding()) {
 
-                    boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
-                    ssoAgentConfig.getSAML2().setPassiveAuthn(false);
-                    String htmlPayload = samlSSOManager.buildPostRequest(request, response, true);
-                    ssoAgentConfig.getSAML2().setPassiveAuthn(isPassiveAuth);
-                    SSOAgentUtils.sendPostResponse(request, response, htmlPayload);
+                        boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
+                        ssoAgentConfig.getSAML2().setPassiveAuthn(false);
+                        String htmlPayload = samlSSOManager.buildPostRequest(request, response, true);
+                        ssoAgentConfig.getSAML2().setPassiveAuthn(isPassiveAuth);
+                        SSOAgentUtils.sendPostResponse(request, response, htmlPayload);
 
-                } else {
-                    //if "SSOAgentConstants.HTTP_BINDING_PARAM" is not defined, default to redirect
-                    boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
-                    ssoAgentConfig.getSAML2().setPassiveAuthn(false);
-                    String redirectUrl = samlSSOManager.buildRedirectRequest(request, true);
-                    ssoAgentConfig.getSAML2().setPassiveAuthn(isPassiveAuth);
-                    response.sendRedirect(redirectUrl);
+                    } else {
+                        //if "SSOAgentConstants.HTTP_BINDING_PARAM" is not defined, default to redirect
+                        boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
+                        ssoAgentConfig.getSAML2().setPassiveAuthn(false);
+                        String redirectUrl = samlSSOManager.buildRedirectRequest(request, true);
+                        ssoAgentConfig.getSAML2().setPassiveAuthn(isPassiveAuth);
+                        response.sendRedirect(redirectUrl);
+                    }
+                } catch (SSOAgentException e) {
+                    if (e instanceof InvalidSessionException) {
+                        // Redirect to the index page when session is expired or user already logged out.
+                        LOGGER.log(Level.FINE, "Invalid Session!", e);
+                        response.sendRedirect(filterConfig.getServletContext().getContextPath());
+                        return;
+                    }
+                    handleException(request, response, ssoAgentConfig, e);
+                    return;
                 }
                 return;
 
             } else if (resolver.isSAML2SSOURL()) {
 
-                samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
-                if (resolver.isHttpPostBinding()) {
-                    String htmlPayload = samlSSOManager.buildPostRequest(request, response, false);
-                    SSOAgentUtils.sendPostResponse(request, response, htmlPayload);
+                try {
+                    samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
+                    if (resolver.isHttpPostBinding()) {
+                        String htmlPayload = samlSSOManager.buildPostRequest(request, response, false);
+                        SSOAgentUtils.sendPostResponse(request, response, htmlPayload);
+                        return;
+                    }
+                    response.sendRedirect(samlSSOManager.buildRedirectRequest(request, false));
+                } catch (SSOAgentException e) {
+                    if (e instanceof InvalidSessionException) {
+                        // Redirect to the index page when session is expired or user already logged out.
+                        LOGGER.log(Level.FINE, "Invalid Session!", e);
+                        response.sendRedirect(filterConfig.getServletContext().getContextPath());
+                        return;
+                    }
+                    handleException(request, response, ssoAgentConfig, e);
                     return;
                 }
-                response.sendRedirect(samlSSOManager.buildRedirectRequest(request, false));
                 return;
 
             } else if (resolver.isPassiveAuthnRequest()) {
 
-                samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
-                boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
-                ssoAgentConfig.getSAML2().setPassiveAuthn(true);
-                String redirectUrl = samlSSOManager.buildRedirectRequest(request, false);
-                ssoAgentConfig.getSAML2().setPassiveAuthn(isPassiveAuth);
-                response.sendRedirect(redirectUrl);
+                try {
+                    samlSSOManager = new SAML2SSOManager(ssoAgentConfig);
+                    boolean isPassiveAuth = ssoAgentConfig.getSAML2().isPassiveAuthn();
+                    ssoAgentConfig.getSAML2().setPassiveAuthn(true);
+                    String redirectUrl = samlSSOManager.buildRedirectRequest(request, false);
+                    ssoAgentConfig.getSAML2().setPassiveAuthn(isPassiveAuth);
+                    response.sendRedirect(redirectUrl);
+                } catch (SSOAgentException e) {
+                    if (e instanceof InvalidSessionException) {
+                        // Redirect to the index page when session is expired or user already logged out.
+                        LOGGER.log(Level.FINE, "Invalid Session!", e);
+                        response.sendRedirect(filterConfig.getServletContext().getContextPath());
+                        return;
+                    }
+                    handleException(request, response, ssoAgentConfig, e);
+                    return;
+                }
                 return;
             }
             String indexPage = ssoAgentConfig.getIndexPage();
             if (request.getSession(false) != null &&
                     request.getSession(false).getAttribute(SSOAgentConstants.SESSION_BEAN_NAME) == null) {
-                request.getSession().invalidate();
                 response.sendRedirect(indexPage);
                 return;
             }
@@ -165,6 +211,7 @@ public class SAML2SSOAgentFilter implements Filter {
                     sessionBean = (LoggedInSessionBean) session.getAttribute(SSOAgentConstants.SESSION_BEAN_NAME);
 
             if (sessionBean == null || sessionBean.getSAML2SSO() == null) {
+                request.getSession().invalidate();
                 response.sendRedirect(indexPage);
                 return;
             }

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
-        <io.asgardeo.java.saml.sdk.version>0.1.11</io.asgardeo.java.saml.sdk.version>
+        <io.asgardeo.java.saml.sdk.version>0.1.13</io.asgardeo.java.saml.sdk.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces the following changes.
- Fix ID validation failures that occur when the browser is refreshed after login into the sample app.
- Fix internal server error message shown in Tomcat instead of showing the specific error via the error page of the sample.
- Fix error shown in Tomcat when trying to logout from the SAML sample app from two logged in browser tabs

Should be merged after https://github.com/asgardeo/asgardeo-java-saml-sdk/pull/22 is merged and a new version of the SDK is released.