### PR TITLE
Add supported features to the SAML application

### DIFF
--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/error.jsp
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/error.jsp
@@ -25,6 +25,7 @@
     <title>An error has occurred</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="theme.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
 <%
     SSOAgentException exception = (SSOAgentException) request.getAttribute(SSOAgentConstants.SSO_AGENT_EXCEPTION);
@@ -47,6 +48,22 @@
                 <h3>
                     <%=exception.getMessage()%>
                 </h3>
+                <div class="message">
+                    <div class="banner">
+                        <span><i class="fa fa-exclamation-circle icon"></i></span>
+                        <div><b>It's possible that you tried an unsupported feature with the sample application.
+                        Currently the below features are supported by this version of the sample 
+                        application</b></div>
+                    </div>
+                    <ul >
+                        <li>SAML single sign on</li>
+                        <li>SAML single logout</li>
+                        <li>Attribute profie</li>
+                        <li>Request signing</li>
+                        <li>Response signing</li>
+                        <li>Assertion signing</li>
+                    </ul> 
+                </div>
             </div>
         </div>
         <img src="images/footer.png" class="footer-image">

--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/error.jsp
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/error.jsp
@@ -48,7 +48,8 @@
                 <h3>
                     <%=exception.getMessage()%>
                 </h3>
-                <div class="message">
+            </div>
+            <div class="message">
                     <div class="banner">
                         <span><i class="fa fa-exclamation-circle icon"></i></span>
                         <div><b>It's possible that you tried an unsupported feature with the sample application.
@@ -64,8 +65,12 @@
                         <li>Assertion signing</li>
                     </ul> 
                 </div>
+                <form action="index.html" method="post">
+                    <div class="element-padding">
+                        <button class="btn primary" type="submit">Back</button>
+                    </div>
+                </form>
             </div>
-        </div>
         <img src="images/footer.png" class="footer-image">
     </div>
 </body>

--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/error.jsp
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/error.jsp
@@ -53,7 +53,7 @@
                     <div class="banner">
                         <span><i class="fa fa-exclamation-circle icon"></i></span>
                         <div><b>It's possible that you tried an unsupported feature with the sample application.
-                        Currently the below features are supported by this version of the sample 
+                        Currently, the below features are supported by this version of the sample 
                         application</b></div>
                     </div>
                     <ul >

--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/theme.css
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/theme.css
@@ -163,19 +163,19 @@ code {
 }
 
 .message {
-    background-color:#FFF6E7; 
-    padding:20px; 
-    text-align:left; 
+    background-color: #FFF6E7; 
+    padding: 20px; 
+    text-align: left; 
     margin: 10px 50px 10px 50px;
 }
 
 .icon {
-    color:#FFA500; 
-    padding-right:4px;
+    color: #FFA500; 
+    padding-right: 4px;
 }
 
 .banner {
-    display:flex;
+    display: flex;
 }
 
 .content {

--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/theme.css
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/theme.css
@@ -41,6 +41,10 @@ a {
     color: #f47421;
 }
 
+li {
+    margin: 5px 0;
+}
+
 a:hover {
     text-decoration: none;;
 }
@@ -156,6 +160,22 @@ code {
     color: #ffffff;
     padding: 20px;
     border-radius: 10px 10px 0 0;
+}
+
+.message {
+    background-color:#FFF6E7; 
+    padding:20px; 
+    text-align:left; 
+    margin: 10px 50px 10px 50px;
+}
+
+.icon {
+    color:#FFA500; 
+    padding-right:4px;
+}
+
+.banner {
+    display:flex;
 }
 
 .content {


### PR DESCRIPTION
### Proposed changes in this pull request
> The current SAML sample does not support some of the SAML features at the moment such as assertion encryption. Hence, when the SAML sample app returns the error page, the user should be notified about which flows are supported so that he can know whether he attempted an unsupported feature with the sample.
> Add the back button in error page

**SAML supported features**

- SAML single sign on
- SAML single logout
- Attribute profie
- Request signing
- Response signing
- Assertion signing

Fixes https://github.com/wso2-enterprise/asgardeo-product/issues/5264