### PR TITLE
Fix the sample-app startup error

### DIFF
--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/resources/sample-app.properties
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/resources/sample-app.properties
@@ -47,7 +47,7 @@ SAML2.EnableRequestSigning=false
 SAML2.IsPassiveAuthn=false
 
 # Pem content of the IDP public certificate
-IdPPublicCert=<CERTIFICATE_PEM_CONTENT>
+#IdPPublicCert=<CERTIFICATE_PEM_CONTENT>
 
 # Password of the KeyStore for SAML and OpenID
 KeyStorePassword=wso2carbon


### PR DESCRIPTION
Fixes: https://github.com/wso2-enterprise/asgardeo-product/issues/7985

This PR comments the `IdPPublicCert=<CERTIFICATE_PEM_CONTENT>` property in the saml-app.properties file.

The `<` and `>` characters are considered invalid characters during the app startup. Therefore it is commented until the correct config is added by a user.