### PR TITLE
Modify the home page to not show the isk value in the attribute section

### DIFF
--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/home.jsp
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/home.jsp
@@ -56,7 +56,12 @@
                 %>
                 <ta>
                 <%
-                    if (saml2SSOAttributes != null && !saml2SSOAttributes.isEmpty()) {
+                    if ((saml2SSOAttributes == null && saml2SSOAttributes.isEmpty()) ||
+                    (saml2SSOAttributes.size() ==1 && saml2SSOAttributes.containsKey("isk"))) {
+                %>
+                    <span>There are no user attributes selected to the application at the moment.</span>
+                <%
+                    } else {
                 %>
                     <table>
                         <tr>
@@ -65,6 +70,9 @@
                         </tr>
                 <%
                         for (Map.Entry<String, String> entry : saml2SSOAttributes.entrySet()) {
+                            if (entry.getKey().equals("isk")) {
+                                continue;
+                            }
                 %>
                         <tr>
                             <td><%=entry.getKey()%></td>
@@ -74,10 +82,6 @@
                         }
                 %>
                     </table>
-                <%
-                    } else {
-                %>
-                    <span>There are no user attributes selected to the application at the moment.</span>
                 <%
                     }
                 %>

--- a/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/home.jsp
+++ b/io.asgardeo.tomcat.saml.agent.sample/src/main/webapp/home.jsp
@@ -57,7 +57,7 @@
                 <ta>
                 <%
                     if ((saml2SSOAttributes == null && saml2SSOAttributes.isEmpty()) ||
-                    (saml2SSOAttributes.size() ==1 && saml2SSOAttributes.containsKey("isk"))) {
+                    (saml2SSOAttributes.size() == 1 && saml2SSOAttributes.containsKey("isk"))) {
                 %>
                     <span>There are no user attributes selected to the application at the moment.</span>
                 <%


### PR DESCRIPTION
### Proposed changes in this pull request

Modify the home.jsp page to not show the `isk` value in the attribute section

Fixes the E2E test failures mentioned in [asgardeo-product #10379](https://github.com/wso2-enterprise/asgardeo-product/issues/10379)