### PR TITLE
Instructs the developer  to create Traditional based web application  in Asgardeo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can experience the capabilities of Asgardeo Tomcat SAML Agent by following t
 Here we are using Asgardeo as the SAML Identity Provider.
 1. Navigate to [**Asgardeo Console**](https://console.asgardeo.io/login) and click on **Applications** under **Develop** tab.
 
-2. Click on **New Application** and then **Standard Based Application**.
+2. Click on **New Application** and then **Traditional Web Application**.
 
 3. Select SAML from the selection and enter any name as the name of the app and add the Assertion Consumer Service URL and Issuer.
 


### PR DESCRIPTION
### Proposed changes in this pull request
In the README file's getting started section, it stated that the developer must create a Standard-Based Application in the Asgardeo console. However, creating a Traditional Based Application, rather than a Standard Based Application, will be more convenient for a developer who is just getting started with the SDK, as it includes a ""Quick Start"" section and also a help guide with samples for the values of each field to be filled at the application registering stage. 

The aforementioned suggestion is incorporated in this PR.


